### PR TITLE
y_axis needs a width to prevent large zone of white space to the left of the chart

### DIFF
--- a/bearcart/templates/y_axis.js
+++ b/bearcart/templates/y_axis.js
@@ -1,6 +1,7 @@
 var y_axis = new Rickshaw.Graph.Axis.Y( {
         graph: graph,
         orientation: 'left',
+        width: 30,
         height: {{ height }},
         tickFormat: Rickshaw.Fixtures.Number.formatKMBT,
         element: d3.select("#{{ y_axis_id }}").node()


### PR DESCRIPTION
Specify a width for y_axis to prevent large zone of white space to the left of the chart i.e. with this change chart is left justified on the page instead of quasi-centered.

Using Chrome 38.0.2125.101 on Ubuntu 14.04 the lack of a width results in a y_axis 350px wide. The Rickshaw generated y-axis is 29px wide so that's 321px of whitespace to the left of the y-axis.
