### PR TITLE
Allows to show graphs from Jupyter notebooks served from https address

### DIFF
--- a/bearcart/templates/ipynb_init_css.html
+++ b/bearcart/templates/ipynb_init_css.html
@@ -1,5 +1,5 @@
-<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/rickshaw/1.3.0/rickshaw.css">
-<link rel="stylesheet" href="http://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css">
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/rickshaw/1.3.0/rickshaw.css">
+<link rel="stylesheet" href="//code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css">
 <style>
   .rickshaw-chart {
       font: 10px sans-serif;

--- a/bearcart/templates/ipynb_init_js.html
+++ b/bearcart/templates/ipynb_init_js.html
@@ -11,15 +11,15 @@
 
  function load_bearcart_libs(){
     console.log('Loading all Bearcart libraries...')
-    $.getScript('http://code.jquery.com/ui/1.10.4/jquery-ui.js', function(){
-      $.getScript('http://cdnjs.cloudflare.com/ajax/libs/rickshaw/1.4.6/rickshaw.min.js', load_cart_charts)
+    $.getScript('//code.jquery.com/ui/1.10.4/jquery-ui.js', function(){
+      $.getScript('//cdnjs.cloudflare.com/ajax/libs/rickshaw/1.4.6/rickshaw.min.js', load_cart_charts)
     })
   };
 
  if(typeof define === "function" && define.amd){
       if (window['d3'] === undefined){
           require.config(
-              {paths: {d3: 'http://d3js.org/d3.v3.min'}
+              {paths: {d3: '//d3js.org/d3.v3.min'}
               }
             );
           require(["d3"], function(d3){


### PR DESCRIPTION
I'm serving up Jupyter notebooks from https address. Similar to this problem in Vincent:https://github.com/wrobstory/vincent/pull/64

Just changed the addresses to get jquery and rickshaw to be protocol-less addresses.
